### PR TITLE
Fix cell row reset on hot reload

### DIFF
--- a/hotswap-agent/src/nipx/uihook/CellPropertyRef.java
+++ b/hotswap-agent/src/nipx/uihook/CellPropertyRef.java
@@ -508,7 +508,7 @@ public class CellPropertyRef {
 		List<PropertyCall> newProperties = newCalls.subList(newCalls.isEmpty() ? 0 : 1, newCalls.size());
 
 		if (elementUpdated || !callsEqual(oldProperties, newProperties)) {
-			cell.set(Cell.defaults());
+			resetCell(cell);
 			applyAllCalls(cell, newProperties);
 			if (DEBUG) {
 				log("[CellProperty] Reapplied property chain due to changes (Element updated: " + elementUpdated + ").");
@@ -518,6 +518,29 @@ public class CellPropertyRef {
 		return false;
 	}
 
+
+	private static void resetCell(Cell<?> cell) {
+		cell.set(Cell.defaults());
+		resetCellEndRow(cell);
+	}
+
+	private static void resetCellEndRow(Cell<?> cell) {
+		for (String fieldName : new String[]{"endRow", "row"}) {
+			try {
+				Field field = Cell.class.getDeclaredField(fieldName);
+				if (field.getType() == boolean.class) {
+					field.setAccessible(true);
+					field.setBoolean(cell, false);
+					return;
+				}
+			} catch (NoSuchFieldException ignored) {
+				// Try the next known field name used by different Arc versions.
+			} catch (IllegalAccessException e) {
+				error("[CellProperty] Failed to reset Cell end-row flag", e);
+				return;
+			}
+		}
+	}
 
 	private static void updateChildElement(Cell<?> cell, PropertyCall creator) {
 		Element oldElement = cell.get();
@@ -703,6 +726,7 @@ public class CellPropertyRef {
 	 "fill", "fillX", "fillY",
 	 "align", "center", "top", "left", "bottom", "right",
 	 "grow", "growX", "growY",
+	 "row",
 	 "expand", "expandX", "expandY",
 	 "colspan",
 	 "uniform", "uniformX", "uniformY",

--- a/test/src/CellPropertyRefTest.java
+++ b/test/src/CellPropertyRefTest.java
@@ -47,6 +47,11 @@ public class CellPropertyRefTest {
             float size = 100f * 3f;
             table.add().size(size, size * 0.7f);
         }
+
+        void testRowProperty(Table table) {
+            table.add().growX().row();
+            table.add().width(42f);
+        }
     }
 
     private byte[] getClassBytecode(Class<?> clazz) throws Exception {
@@ -100,6 +105,12 @@ public class CellPropertyRefTest {
         assertEquals(1, arithmeticChains.size());
         assertEquals(300.0f, arithmeticChains.get(0).get(0).args()[0]);
         assertEquals(210.0f, arithmeticChains.get(0).get(0).args()[1]);
+
+        // Verify row() is tracked as a cell property so hot reload can keep row boundaries.
+        List<List<CellPropertyRef.PropertyCall>> rowChains = findChains(chains, "testRowProperty");
+        assertNotNull(rowChains);
+        assertEquals(2, rowChains.size());
+        assertEquals("row", rowChains.get(0).get(2).method());
     }
 
     private List<List<CellPropertyRef.PropertyCall>> findChains(Map<String, List<List<CellPropertyRef.PropertyCall>>> chains, String methodName) {


### PR DESCRIPTION
### Motivation
- Hot-reloading cell properties used `cell.set(Cell.defaults())` but left the internal end-row flag set, causing `cell.row()`/`isEndRow` to remain true and breaking subsequent layout rows.
- `.row()` was not tracked as a cell property in the bytecode extractor, so row boundaries could be lost during replay.

### Description
- Replace direct `cell.set(Cell.defaults())` calls in the replay path with `resetCell(cell)` which calls `cell.set(Cell.defaults())` and then clears the internal end-row flag via reflection. 
- Add `resetCellEndRow` that tries known Arc field names `endRow` and `row` and resets the boolean flag to `false`, logging on access failures.
- Add `"row"` to `CELL_PROPERTY_METHODS` so the ASM extractor treats `.row()` as a cell property and preserves row boundaries in extracted chains.
- Add a unit test `testRowProperty` in `CellPropertyRefTest` that exercises a chained `.growX().row()` followed by another cell and asserts the extractor yields two chains and that one of the calls is `row`.

### Testing
- Ran `git diff --check` which passed.
- Attempted `./gradlew :test:test --tests CellPropertyRefTest` but execution was blocked by missing `ANDROID_HOME` platform resolution, causing the evaluation error for `platformRoot`.
- Attempted `ANDROID_HOME=/tmp/android-sdk ./gradlew :test:test --tests CellPropertyRefTest`, but dependency resolution failed due to JitPack returning HTTP 403 for required artifacts, blocking test execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a578ae153bc83228ac215131a096d29)